### PR TITLE
release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@
 
 ### Features
 - Add list of ids into import returns
+- Add "externals" field into survey unit: save in database without modification
+
+### Refactoring
+- use JsonView to manage the fields to return
+- add content description in the OpenAPI documentation
 
 ### Dependencies updates
 - spring-boot: 3.1.0 -> 3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@
 - Add list of ids into import returns
 - Add "externals" field into survey unit: save in database without modification
 - Add number of SurveyUnit into partition endpoint
-- WIP: Import census survey units
+- Import census survey units
+- Empty a partition
 
 ### Refactoring
 - use JsonView to manage the fields to return
@@ -71,4 +72,4 @@
 
 ### Dependencies updates
 - spring-boot: 3.1.0 -> 3.1.1
-- pitest-maven: 1.14.1 -> 1.14.2
+- pitest-maven: 1.14.1 -> 1.14.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@
 ### Features
 - Add list of ids into import returns
 - Add "externals" field into survey unit: save in database without modification
+- Add number of SurveyUnit into partition endpoint
+- WIP: Import census survey units
 
 ### Refactoring
 - use JsonView to manage the fields to return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 ### Refactoring
 - use JsonView to manage the fields to return
 - add content description in the OpenAPI documentation
+- delete Serializable from Entity classes
 
 ### Dependencies updates
 - spring-boot: 3.1.0 -> 3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Import new survey units from a json and add them to the new partition
 
 #### Manage a partition of survey units
-- Add a existing survey unit to another partition
+- Add an existing survey unit to another partition
 - Add a list of survey units to another partition
 - Remove a survey unit from a partition (survey unit is not deleted)
 
@@ -55,3 +55,12 @@
 - Created ApiError class to manage errors feedback
 - Used Tags for groups of endpoints
 - Replace name of TypeUnit enum to Context
+
+## 1.3.0
+
+### Features
+- Add list of ids into import returns
+
+### Dependencies updates
+- spring-boot: 3.1.0 -> 3.1.1
+- pitest-maven: 1.14.1 -> 1.14.2

--- a/application/src/main/java/fr/insee/rem/application/config/PortConfig.java
+++ b/application/src/main/java/fr/insee/rem/application/config/PortConfig.java
@@ -1,8 +1,5 @@
 package fr.insee.rem.application.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import fr.insee.rem.domain.ports.api.PartitionServicePort;
 import fr.insee.rem.domain.ports.api.SurveyUnitServicePort;
 import fr.insee.rem.domain.ports.spi.PartitionPersistencePort;
@@ -13,6 +10,8 @@ import fr.insee.rem.domain.service.SurveyUnitServiceImpl;
 import fr.insee.rem.infrastructure.adapter.PartitionJpaAdapter;
 import fr.insee.rem.infrastructure.adapter.PartitionSurveyUnitLinkJpaAdapter;
 import fr.insee.rem.infrastructure.adapter.SurveyUnitJpaAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class PortConfig {
@@ -34,7 +33,7 @@ public class PortConfig {
 
     @Bean
     PartitionServicePort partitionService() {
-        return new PartitionServiceImpl(partitionPersistance());
+        return new PartitionServiceImpl(partitionPersistance(), partitionSurveyUnitLinkPersistance());
     }
 
     @Bean

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -52,6 +52,9 @@ springdoc.swagger-ui.operationsSorter=alpha
 #For sorting tags alphabetically
 springdoc.swagger-ui.tagsSorter=alpha
 
+# Mapper default view
+spring.jackson.mapper.default-view-inclusion=true
+
 
 
 

--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -8,7 +8,7 @@
 		<version>${revision}</version>
 	</parent>
 	<artifactId>controller</artifactId>
-	<description>Survey unit repository - Rest Controler</description>
+	<description>Survey unit repository - Rest Controller</description>
 	<dependencies>
 	
 		<dependency>
@@ -34,6 +34,12 @@
 		    <groupId>com.opencsv</groupId>
 		    <artifactId>opencsv</artifactId>
 		    <version>5.7.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 		    <groupId>org.geotools</groupId>

--- a/controller/src/main/java/fr/insee/rem/controller/adapter/CensusAdapter.java
+++ b/controller/src/main/java/fr/insee/rem/controller/adapter/CensusAdapter.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class CensusAdapter {
     public SurveyUnitDto convert(CensusSource c) {
 
-        return SurveyUnitDto.builder().externalId(c.getIdinternaute()).context(Context.HOUSEHOLD)
+        return SurveyUnitDto.builder().externalId(String.valueOf(c.getId())).context(Context.HOUSEHOLD)
                 .address(convertAddress(c)).persons(convertPersons(c))
                 .additionalInformations(convertAdditionalInformation(c))
                 .externals(c.getExternals()).build();
@@ -18,19 +18,20 @@ public class CensusAdapter {
 
     private List<AdditionalInformationDto> convertAdditionalInformation(CensusSource c) {
         AdditionalInformationDto addInfo = AdditionalInformationDto.builder()
-                .key("identifiantCompte").value(c.getIdentifiant()).build();
+                .key("identifiantCompte").value(c.getIdentifiantCompte()).build();
         return List.of(addInfo);
     }
 
     private List<PersonDto> convertPersons(CensusSource c) {
         EmailDto mail = EmailDto.builder().favorite(false).source(Source.INITIAL).mailAddress(c.getMail()).build();
-        PersonDto main = PersonDto.builder().index(1).main(true).externalId(c.getIdenq()).emails(List.of(mail)).build();
+        PersonDto main = PersonDto.builder().index(1).main(true).externalId(String.valueOf(c.getIdInternaute()))
+                .emails(List.of(mail)).build();
         return List.of(main);
     }
 
     private AddressDto convertAddress(CensusSource c) {
         return AddressDto.builder().streetNumber(c.getNumvoiloc()).repetitionIndex(c.getBisterloc())
                 .streetType(c.getTypevoiloc()).streetName(c.getNomvoiloc()).addressSupplement(c.getResloc())
-                .cityName(c.getCloc()).zipCode(c.getCpostloc()).build();
+                .cityName(c.getCar()).zipCode(c.getCpostloc()).build();
     }
 }

--- a/controller/src/main/java/fr/insee/rem/controller/adapter/CensusAdapter.java
+++ b/controller/src/main/java/fr/insee/rem/controller/adapter/CensusAdapter.java
@@ -1,13 +1,36 @@
 package fr.insee.rem.controller.adapter;
 
 import fr.insee.rem.controller.sources.CensusSource;
-import fr.insee.rem.domain.dtos.SurveyUnitDto;
+import fr.insee.rem.domain.dtos.*;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class CensusAdapter {
     public SurveyUnitDto convert(CensusSource c) {
 
-        return SurveyUnitDto.builder().build();
+        return SurveyUnitDto.builder().externalId(c.getIdinternaute()).context(Context.HOUSEHOLD)
+                .address(convertAddress(c)).persons(convertPersons(c))
+                .additionalInformations(convertAdditionalInformation(c))
+                .externals(c.getExternals()).build();
+    }
+
+    private List<AdditionalInformationDto> convertAdditionalInformation(CensusSource c) {
+        AdditionalInformationDto addInfo = AdditionalInformationDto.builder()
+                .key("identifiantCompte").value(c.getIdentifiant()).build();
+        return List.of(addInfo);
+    }
+
+    private List<PersonDto> convertPersons(CensusSource c) {
+        EmailDto mail = EmailDto.builder().favorite(false).source(Source.INITIAL).mailAddress(c.getMail()).build();
+        PersonDto main = PersonDto.builder().index(1).main(true).externalId(c.getIdenq()).emails(List.of(mail)).build();
+        return List.of(main);
+    }
+
+    private AddressDto convertAddress(CensusSource c) {
+        return AddressDto.builder().streetNumber(c.getNumvoiloc()).repetitionIndex(c.getBisterloc())
+                .streetType(c.getTypevoiloc()).streetName(c.getNomvoiloc()).addressSupplement(c.getResloc())
+                .cityName(c.getCloc()).zipCode(c.getCpostloc()).build();
     }
 }

--- a/controller/src/main/java/fr/insee/rem/controller/adapter/CensusAdapter.java
+++ b/controller/src/main/java/fr/insee/rem/controller/adapter/CensusAdapter.java
@@ -1,0 +1,13 @@
+package fr.insee.rem.controller.adapter;
+
+import fr.insee.rem.controller.sources.CensusSource;
+import fr.insee.rem.domain.dtos.SurveyUnitDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CensusAdapter {
+    public SurveyUnitDto convert(CensusSource c) {
+
+        return SurveyUnitDto.builder().build();
+    }
+}

--- a/controller/src/main/java/fr/insee/rem/controller/exception/ApiError.java
+++ b/controller/src/main/java/fr/insee/rem/controller/exception/ApiError.java
@@ -29,8 +29,8 @@ public class ApiError {
         if (errorMessage == null || errorMessage.isEmpty()) {
             errorMessage = status.getReasonPhrase();
         }
-        String path = ((ServletWebRequest) request).getRequest().getRequestURI();
-        createApiError(status.value(), path, timestamp, errorMessage);
+        createApiError(status.value(), ((ServletWebRequest) request).getRequest().getRequestURI(), timestamp,
+                errorMessage);
     }
 
     private void createApiError(int code, String path, LocalDateTime timestamp, String errorMessage) {

--- a/controller/src/main/java/fr/insee/rem/controller/response/PartitionWithCount.java
+++ b/controller/src/main/java/fr/insee/rem/controller/response/PartitionWithCount.java
@@ -1,0 +1,20 @@
+package fr.insee.rem.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import fr.insee.rem.domain.dtos.PartitionDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PartitionWithCount {
+    
+    @JsonUnwrapped
+    private PartitionDto partition;
+    private long count;
+
+}

--- a/controller/src/main/java/fr/insee/rem/controller/response/Response.java
+++ b/controller/src/main/java/fr/insee/rem/controller/response/Response.java
@@ -3,28 +3,15 @@ package fr.insee.rem.controller.response;
 import org.springframework.http.HttpStatus;
 
 public class Response {
-    /**
-     * label
-     */
     private String message;
 
     private HttpStatus httpStatus;
 
-    /**
-     * Defaut constructor for a Status
-     * 
-     * @param label
-     */
     public Response(String message, HttpStatus httpStatus) {
         this.message = message;
         this.httpStatus = httpStatus;
     }
 
-    /**
-     * Get the label for a Status
-     * 
-     * @return label
-     */
     public String getMessage() {
         return message;
     }

--- a/controller/src/main/java/fr/insee/rem/controller/response/SuIdMappingCsv.java
+++ b/controller/src/main/java/fr/insee/rem/controller/response/SuIdMappingCsv.java
@@ -1,7 +1,6 @@
-package fr.insee.rem.controller.targets;
+package fr.insee.rem.controller.response;
 
 import com.opencsv.bean.CsvBindByName;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class SuIdMappingCsvTarget {
+public class SuIdMappingCsv {
 
     @CsvBindByName(column = "ID_REM")
     private String idRem;

--- a/controller/src/main/java/fr/insee/rem/controller/response/SuIdMappingJson.java
+++ b/controller/src/main/java/fr/insee/rem/controller/response/SuIdMappingJson.java
@@ -1,4 +1,4 @@
-package fr.insee.rem.controller.targets;
+package fr.insee.rem.controller.response;
 
 import fr.insee.rem.domain.records.SuIdMappingRecord;
 import lombok.AllArgsConstructor;
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class SuIdMappingJsonTarget {
+public class SuIdMappingJson {
     private long partitionId;
     private List<SuIdMappingRecord> data;
     private int count;

--- a/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
+++ b/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
@@ -114,7 +114,6 @@ public class PartitionController {
     public ResponseEntity<PartitionWithCount> emptyPartition(@PathVariable("partitionId") final Long partitionId) {
         log.info("Empty partition {}", partitionId);
         partitionService.emptyPartitionById(partitionId);
-        Response response = new Response(String.format("partition %s empty", partitionId), HttpStatus.OK);
         PartitionDto partition = partitionService.getPartitionById(partitionId);
         long count = surveyUnitService.countSurveyUnitsByPartition(partitionId);
         return new ResponseEntity<>(PartitionWithCount.builder().partition(partition).count(count).build(),

--- a/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
+++ b/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
@@ -102,4 +102,22 @@ public class PartitionController {
                 response.getMessage());
         return ResponseEntity.ok(response);
     }
+
+    @Tag(name = "5. Clean data")
+    @Operation(summary = "Empty a partition", responses = {
+            @ApiResponse(responseCode = "200", description = "Partition successfully emptied", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionWithCount.class))),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    })
+    @DeleteMapping(path = "/{partitionId}/empty")
+    public ResponseEntity<PartitionWithCount> emptyPartition(@PathVariable("partitionId") final Long partitionId) {
+        log.info("Empty partition {}", partitionId);
+        partitionService.emptyPartitionById(partitionId);
+        Response response = new Response(String.format("partition %s empty", partitionId), HttpStatus.OK);
+        PartitionDto partition = partitionService.getPartitionById(partitionId);
+        long count = surveyUnitService.countSurveyUnitsByPartition(partitionId);
+        return new ResponseEntity<>(PartitionWithCount.builder().partition(partition).count(count).build(),
+                HttpStatus.OK);
+    }
 }

--- a/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
+++ b/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
@@ -1,9 +1,12 @@
 package fr.insee.rem.controller.rest;
 
+import fr.insee.rem.controller.exception.ApiError;
 import fr.insee.rem.controller.response.Response;
 import fr.insee.rem.domain.dtos.PartitionDto;
 import fr.insee.rem.domain.ports.api.PartitionServicePort;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
@@ -30,8 +33,10 @@ public class PartitionController {
             @Tag(name = "1. Import data")
     })
     @Operation(summary = "Create partition", responses = {
-            @ApiResponse(responseCode = "200", description = "Partition successfully created"),
-            @ApiResponse(responseCode = "409", description = "Partition Already Exists")
+            @ApiResponse(responseCode = "200", description = "Partition successfully created", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionDto.class))),
+            @ApiResponse(responseCode = "409", description = "Partition Already Exists", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping(path = "/", consumes = {
             MediaType.TEXT_PLAIN_VALUE
@@ -43,8 +48,10 @@ public class PartitionController {
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Get partition", responses = {
-            @ApiResponse(responseCode = "200", description = "Partition successfully recovered"),
-            @ApiResponse(responseCode = "404", description = "Partition Not Found")
+            @ApiResponse(responseCode = "200", description = "Partition successfully recovered", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionDto.class))),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping(path = "/{partitionId}")
     public ResponseEntity<PartitionDto> getPartition(@PathVariable("partitionId") final Long partitionId) {
@@ -54,7 +61,8 @@ public class PartitionController {
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Get all partitions", responses = {
-            @ApiResponse(responseCode = "200", description = "Partitions successfully recovered")
+            @ApiResponse(responseCode = "200", description = "Partitions successfully recovered", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionDto.class)))
     })
     @GetMapping(path = "/")
     public ResponseEntity<List<PartitionDto>> getAllPartitions() {
@@ -64,8 +72,10 @@ public class PartitionController {
 
     @Tag(name = "5. Clean data")
     @Operation(summary = "Delete partition", responses = {
-            @ApiResponse(responseCode = "200", description = "Partition successfully deleted"),
-            @ApiResponse(responseCode = "404", description = "Partition Not Found")
+            @ApiResponse(responseCode = "200", description = "Partition successfully deleted", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @DeleteMapping(path = "/{partitionId}")
     public ResponseEntity<Object> deletePartition(@PathVariable("partitionId") final Long partitionId) {

--- a/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
+++ b/controller/src/main/java/fr/insee/rem/controller/rest/PartitionController.java
@@ -1,9 +1,11 @@
 package fr.insee.rem.controller.rest;
 
 import fr.insee.rem.controller.exception.ApiError;
+import fr.insee.rem.controller.response.PartitionWithCount;
 import fr.insee.rem.controller.response.Response;
 import fr.insee.rem.domain.dtos.PartitionDto;
 import fr.insee.rem.domain.ports.api.PartitionServicePort;
+import fr.insee.rem.domain.ports.api.SurveyUnitServicePort;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -28,46 +30,60 @@ public class PartitionController {
     @Autowired
     PartitionServicePort partitionService;
 
+    @Autowired
+    SurveyUnitServicePort surveyUnitService;
+
     @Tags(value = {
             @Tag(name = "3. Manage a partition"),
             @Tag(name = "1. Import data")
     })
     @Operation(summary = "Create partition", responses = {
             @ApiResponse(responseCode = "200", description = "Partition successfully created", content =
-            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionDto.class))),
+            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionWithCount.class))),
             @ApiResponse(responseCode = "409", description = "Partition Already Exists", content =
             @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping(path = "/", consumes = {
             MediaType.TEXT_PLAIN_VALUE
     })
-    public ResponseEntity<PartitionDto> createPartition(@RequestBody String label) {
+    public ResponseEntity<PartitionWithCount> createPartition(@RequestBody String label) {
         log.info("POST create partition {}", label);
-        return new ResponseEntity<>(partitionService.createPartition(label), HttpStatus.OK);
+        PartitionDto partition = partitionService.createPartition(label);
+        return new ResponseEntity<>(PartitionWithCount.builder().partition(partition).count(0).build(), HttpStatus.OK);
     }
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Get partition", responses = {
             @ApiResponse(responseCode = "200", description = "Partition successfully recovered", content =
-            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionDto.class))),
+            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionWithCount.class))),
             @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
             @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping(path = "/{partitionId}")
-    public ResponseEntity<PartitionDto> getPartition(@PathVariable("partitionId") final Long partitionId) {
+    public ResponseEntity<PartitionWithCount> getPartition(@PathVariable("partitionId") final Long partitionId) {
         log.info("Get partition {}", partitionId);
-        return new ResponseEntity<>(partitionService.getPartitionById(partitionId), HttpStatus.OK);
+        PartitionDto partition = partitionService.getPartitionById(partitionId);
+        long count = surveyUnitService.countSurveyUnitsByPartition(partitionId);
+        return new ResponseEntity<>(PartitionWithCount.builder().partition(partition).count(count).build(),
+                HttpStatus.OK);
     }
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Get all partitions", responses = {
             @ApiResponse(responseCode = "200", description = "Partitions successfully recovered", content =
-            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionDto.class)))
+            @Content(mediaType = "application/json", schema = @Schema(implementation = PartitionWithCount.class)))
     })
     @GetMapping(path = "/")
-    public ResponseEntity<List<PartitionDto>> getAllPartitions() {
+    public ResponseEntity<List<PartitionWithCount>> getAllPartitions() {
         log.info("Get all partitions");
-        return new ResponseEntity<>(partitionService.getAllPartitions(), HttpStatus.OK);
+        List<PartitionDto> partitionDtoList = partitionService.getAllPartitions();
+        List<PartitionWithCount> partitionWithCountList =
+                partitionDtoList.stream().map(dto -> PartitionWithCount.builder()
+                                .partition(dto)
+                                .count(surveyUnitService.countSurveyUnitsByPartition(dto.getPartitionId()))
+                                .build())
+                        .toList();
+        return new ResponseEntity<>(partitionWithCountList, HttpStatus.OK);
     }
 
     @Tag(name = "5. Clean data")
@@ -78,12 +94,12 @@ public class PartitionController {
             @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @DeleteMapping(path = "/{partitionId}")
-    public ResponseEntity<Object> deletePartition(@PathVariable("partitionId") final Long partitionId) {
+    public ResponseEntity<Response> deletePartition(@PathVariable("partitionId") final Long partitionId) {
         log.info("DELETE partition {}", partitionId);
         partitionService.deletePartitionById(partitionId);
         Response response = new Response(String.format("partition %s deleted", partitionId), HttpStatus.OK);
         log.info("DELETE /partitions/{partitionId} resulting in {} with response [{}]", response.getHttpStatus(),
                 response.getMessage());
-        return new ResponseEntity<>(response.getMessage(), response.getHttpStatus());
+        return ResponseEntity.ok(response);
     }
 }

--- a/controller/src/main/java/fr/insee/rem/controller/rest/SurveyUnitController.java
+++ b/controller/src/main/java/fr/insee/rem/controller/rest/SurveyUnitController.java
@@ -1,6 +1,8 @@
 package fr.insee.rem.controller.rest;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import fr.insee.rem.controller.adapter.HouseholdCsvAdapter;
+import fr.insee.rem.controller.exception.ApiError;
 import fr.insee.rem.controller.exception.CsvFileException;
 import fr.insee.rem.controller.response.Response;
 import fr.insee.rem.controller.sources.HouseholdCsvSource;
@@ -14,7 +16,11 @@ import fr.insee.rem.domain.exception.PartitionNotFoundException;
 import fr.insee.rem.domain.exception.SettingsException;
 import fr.insee.rem.domain.ports.api.SurveyUnitServicePort;
 import fr.insee.rem.domain.records.SuIdMappingRecord;
+import fr.insee.rem.domain.views.Views;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +30,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJacksonValue;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -46,9 +53,12 @@ public class SurveyUnitController {
 
     @Tag(name = "1. Import data")
     @Operation(summary = "Add Household SurveyUnits into existing partition from CSV file", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully added"),
-            @ApiResponse(responseCode = "400", description = "CSV File Error"),
-            @ApiResponse(responseCode = "404", description = "Partition Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully added", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = SuIdMappingJsonTarget.class))),
+            @ApiResponse(responseCode = "400", description = "CSV File Error", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content = @Content(schema =
+            @Schema(implementation = ApiError.class)))
     })
     @PostMapping(path = "/households/partitions/{partitionId}/csv-upload", consumes = {
             MediaType.MULTIPART_FORM_DATA_VALUE
@@ -58,11 +68,9 @@ public class SurveyUnitController {
             @RequestPart("partition") MultipartFile partitionFile) throws PartitionNotFoundException, CsvFileException {
         log.info("POST add partition {} from csv file {}", partitionId, partitionFile.getOriginalFilename());
         List<HouseholdCsvSource> householdCsvList = CsvToBeanUtils.parse(partitionFile, HouseholdCsvSource.class);
-        List<SurveyUnitDto> surveyUnits = householdCsvList.stream().map(h -> householdCsvAdapter.convert(h))
-                .toList();
+        List<SurveyUnitDto> surveyUnits = householdCsvList.stream().map(h -> householdCsvAdapter.convert(h)).toList();
         List<PartitionSurveyUnitLinkDto> importedPartitionSurveyUnitLinks =
-                surveyUnitService.importSurveyUnitsIntoPartition(partitionId,
-                        surveyUnits);
+                surveyUnitService.importSurveyUnitsIntoPartition(partitionId, surveyUnits);
         SuIdMappingJsonTarget suIdMappingJsonTarget = SuIdMappingJsonTarget.builder()
                 .partitionId(partitionId)
                 .data(importedPartitionSurveyUnitLinks.stream()
@@ -76,20 +84,22 @@ public class SurveyUnitController {
 
     @Tag(name = "1. Import data")
     @Operation(summary = "Add Household SurveyUnits into existing partition from json (REM Model)", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully added"),
-            @ApiResponse(responseCode = "404", description = "Partition Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully added", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = SuIdMappingJsonTarget.class))),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping(path = "/households/partitions/{partitionId}/json-upload")
     public ResponseEntity<SuIdMappingJsonTarget> addHouseholdSurveyUnitsFromJson(
-            @PathVariable("partitionId") final Long partitionId, @RequestBody List<SurveyUnitDto> surveyUnits) {
+            @PathVariable("partitionId") final Long partitionId,
+            @RequestBody @JsonView(Views.SurveyUnitWithExternals.class) List<SurveyUnitDto> surveyUnits) {
         log.info("POST add partition {} from json", partitionId);
         boolean hasRepositoryId = surveyUnitService.checkRepositoryId(surveyUnits);
         if (hasRepositoryId) {
             throw new SettingsException("Survey units already contain a repository identifier");
         }
         List<PartitionSurveyUnitLinkDto> importedPartitionSurveyUnitLinks =
-                surveyUnitService.importSurveyUnitsIntoPartition(partitionId,
-                        surveyUnits);
+                surveyUnitService.importSurveyUnitsIntoPartition(partitionId, surveyUnits);
 
         SuIdMappingJsonTarget suIdMappingJsonTarget = SuIdMappingJsonTarget.builder()
                 .partitionId(partitionId)
@@ -104,8 +114,10 @@ public class SurveyUnitController {
 
     @Tag(name = "3. Manage a partition")
     @Operation(summary = "Add SurveyUnit to Partition", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully added"),
-            @ApiResponse(responseCode = "404", description = "Partition or SurveyUnit Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully added", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "404", description = "Partition or SurveyUnit Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PutMapping(path = "/{surveyUnitId}/partitions/{partitionId}")
     public ResponseEntity<Object> addSurveyUnitToPartition(
@@ -113,22 +125,22 @@ public class SurveyUnitController {
             @PathVariable("partitionId") final Long partitionId) {
         log.info("PUT Add SurveyUnit {} to Partition {}", surveyUnitId, partitionId);
         PartitionSurveyUnitLinkDto newPartitionSurveyUnitLink =
-                surveyUnitService.addExistingSurveyUnitIntoPartition(surveyUnitId,
-                        partitionId);
+                surveyUnitService.addExistingSurveyUnitIntoPartition(surveyUnitId, partitionId);
         Response response = new Response(String.format("SurveyUnit %s add to partition %s",
-                newPartitionSurveyUnitLink.getSurveyUnit()
-                        .getRepositoryId(), newPartitionSurveyUnitLink.getPartition().getPartitionId()), HttpStatus.OK);
+                newPartitionSurveyUnitLink.getSurveyUnit().getRepositoryId(),
+                newPartitionSurveyUnitLink.getPartition().getPartitionId()), HttpStatus.OK);
         log.info("PUT /survey-units/{surveyUnitId}/partitions/{partitionId} resulting in {} with response [{}]",
-                response
-                        .getHttpStatus(), response.getMessage());
+                response.getHttpStatus(), response.getMessage());
 
         return new ResponseEntity<>(response.getMessage(), response.getHttpStatus());
     }
 
     @Tag(name = "3. Manage a partition")
     @Operation(summary = "Add SurveyUnits List to Partition", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully added"),
-            @ApiResponse(responseCode = "404", description = "Partition or SurveyUnit Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully added", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "404", description = "Partition or SurveyUnit Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PutMapping(path = "/partitions/{partitionId}")
     public ResponseEntity<Object> addSurveyUnitsToPartition(@RequestBody List<Long> surveyUnitIds, @PathVariable(
@@ -136,13 +148,13 @@ public class SurveyUnitController {
         log.info("PUT Add SurveyUnits List to Partition {}", partitionId);
         if (surveyUnitIds == null || surveyUnitIds.isEmpty()) {
             Response response = new Response("SurveyUnits List empty", HttpStatus.BAD_REQUEST);
-            log.info("PUT /survey-units/partitions/{partitionId} resulting in {} with response [{}]", response
-                    .getHttpStatus(), response.getMessage());
+            log.info("PUT /survey-units/partitions/{partitionId} resulting in {} with response [{}]",
+                    response.getHttpStatus(), response.getMessage());
             return new ResponseEntity<>(response.getMessage(), response.getHttpStatus());
         }
         int count = surveyUnitService.addExistingSurveyUnitsToPartition(surveyUnitIds, partitionId);
-        Response response = new Response(String
-                .format("%s SurveyUnits add to partition %s", count, partitionId), HttpStatus.OK);
+        Response response = new Response(String.format("%s SurveyUnits add to partition %s", count, partitionId)
+                , HttpStatus.OK);
         log.info("PUT /survey-units/partitions/{partitionId} resulting in {} with response [{}]", response
                 .getHttpStatus(), response.getMessage());
 
@@ -151,19 +163,31 @@ public class SurveyUnitController {
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Get SurveyUnit by Id", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully recovered"),
-            @ApiResponse(responseCode = "404", description = "SurveyUnit Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully recovered", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = SurveyUnitDto.class))),
+            @ApiResponse(responseCode = "404", description = "SurveyUnit Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping(path = "/{surveyUnitId}")
-    public ResponseEntity<SurveyUnitDto> getSurveyUnit(@PathVariable("surveyUnitId") final Long surveyUnitId) {
-        log.info("GET SurveyUnit {}", surveyUnitId);
-        return new ResponseEntity<>(surveyUnitService.getSurveyUnitById(surveyUnitId), HttpStatus.OK);
+    public ResponseEntity<MappingJacksonValue> getSurveyUnit(
+            @PathVariable("surveyUnitId") final Long surveyUnitId,
+            @RequestParam(name = "withExternals", defaultValue = "false", required = false) final boolean withExternals) {
+        log.info("GET SurveyUnit {}, withExternals: {}", surveyUnitId, withExternals);
+        SurveyUnitDto surveyUnit = surveyUnitService.getSurveyUnitById(surveyUnitId);
+        MappingJacksonValue result = new MappingJacksonValue(surveyUnit);
+        result.setSerializationView(Views.SurveyUnitWithId.class);
+        if (withExternals) {
+            result.setSerializationView(Views.SurveyUnitWithIdAndExternals.class);
+        }
+        return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
     @Tag(name = "5. Clean data")
     @Operation(summary = "Delete SurveyUnit", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully deleted"),
-            @ApiResponse(responseCode = "404", description = "SurveyUnit Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully deleted", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "404", description = "SurveyUnit Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @DeleteMapping(path = "/{surveyUnitId}")
     public ResponseEntity<Object> deleteSurveyUnit(@PathVariable("surveyUnitId") final Long surveyUnitId) {
@@ -177,12 +201,15 @@ public class SurveyUnitController {
 
     @Tag(name = "3. Manage a partition")
     @Operation(summary = "Remove SurveyUnit from Partition", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully removed"),
-            @ApiResponse(responseCode = "404", description = "Partition or SurveyUnit Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully removed", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "404", description = "Partition or SurveyUnit Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @DeleteMapping(path = "/{surveyUnitId}/partitions/{partitionId}")
-    public ResponseEntity<Object> removeSurveyUnitFromPartition(@PathVariable("surveyUnitId") final Long surveyUnitId,
-                                                                @PathVariable("partitionId") final Long partitionId) {
+    public ResponseEntity<Object> removeSurveyUnitFromPartition(
+            @PathVariable("surveyUnitId") final Long surveyUnitId,
+            @PathVariable("partitionId") final Long partitionId) {
         log.info("DELETE Remove SurveyUnit {} from Partition {}", surveyUnitId, partitionId);
         surveyUnitService.removeSurveyUnitFromPartition(surveyUnitId, partitionId);
         Response response = new Response(String
@@ -194,22 +221,35 @@ public class SurveyUnitController {
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Get SurveyUnits by Partition", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully recovered"),
-            @ApiResponse(responseCode = "404", description = "Partition Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnits successfully recovered", content =
+            @Content(mediaType = "application/json", array =
+            @ArraySchema(schema = @Schema(implementation = SurveyUnitDto.class)))),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping(path = "/partitions/{partitionId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<SurveyUnitDto>> getSurveyUnitsByPartition(@PathVariable("partitionId") final Long partitionId) {
+    public ResponseEntity<MappingJacksonValue> getSurveyUnitsByPartition(
+            @PathVariable("partitionId") final Long partitionId, @RequestParam(name = "withExternals",
+            defaultValue = "false", required = false) final boolean withExternals) {
         log.info("Get SurveyUnits by Partition {}", partitionId);
         List<SurveyUnitDto> suList = surveyUnitService.getSurveyUnitsByPartitionId(partitionId).stream()
-                .map(PartitionSurveyUnitLinkDto::getSurveyUnit).sorted(Comparator.comparing(SurveyUnitDto::getRepositoryId))
+                .map(PartitionSurveyUnitLinkDto::getSurveyUnit)
+                .sorted(Comparator.comparing(SurveyUnitDto::getRepositoryId))
                 .toList();
-        return new ResponseEntity<>(suList, HttpStatus.OK);
+        MappingJacksonValue result = new MappingJacksonValue(suList);
+        result.setSerializationView(Views.SurveyUnitWithId.class);
+        if (withExternals) {
+            result.setSerializationView(Views.SurveyUnitWithIdAndExternals.class);
+        }
+        return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Get list of Survey Units Ids", responses = {
-            @ApiResponse(responseCode = "200", description = "List of Survey Units Ids successfully recovered"),
-            @ApiResponse(responseCode = "404", description = "Partition Not Found")
+            @ApiResponse(responseCode = "200", description = "Survey Units Ids successfully recovered", content =
+            @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(type = "integer")))),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping(path = "/partitions/{partitionId}/ids")
     public ResponseEntity<List<Long>> getListOfIds(@PathVariable("partitionId") final Long partitionId) {
@@ -221,8 +261,10 @@ public class SurveyUnitController {
 
     @Tag(name = "2. Export data")
     @Operation(summary = "Export identifiers mapping table", responses = {
-            @ApiResponse(responseCode = "200", description = "Identifiers mapping table successfully recovered"),
-            @ApiResponse(responseCode = "404", description = "Partition Not Found")
+            @ApiResponse(responseCode = "200", description = "Identifiers mapping table successfully recovered",
+                    content = @Content(mediaType = "text/csv")),
+            @ApiResponse(responseCode = "404", description = "Partition Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping(path = "/partitions/{partitionId}/ids-mapping-table", produces = "text/csv")
     public ResponseEntity<Object> getIdentifiersMappingTable(@PathVariable("partitionId") final Long partitionId) {
@@ -242,12 +284,15 @@ public class SurveyUnitController {
 
     @Tag(name = "4. Update data")
     @Operation(summary = "Replace SurveyUnit Data", responses = {
-            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully updated"),
-            @ApiResponse(responseCode = "400", description = "Data error"),
-            @ApiResponse(responseCode = "404", description = "SurveyUnit Not Found")
+            @ApiResponse(responseCode = "200", description = "SurveyUnit successfully updated", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "400", description = "Data error", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+            @ApiResponse(responseCode = "404", description = "SurveyUnit Not Found", content =
+            @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PutMapping(path = "/update")
-    public ResponseEntity<Object> replaceSurveyUnitData(@RequestBody SurveyUnitDto surveyUnit) {
+    public ResponseEntity<Object> replaceSurveyUnitData(@RequestBody @JsonView(Views.SurveyUnitWithIdAndExternals.class) SurveyUnitDto surveyUnit) {
         log.info("PUT Replace SurveyUnit data replaced");
         SurveyUnitDto updatedSurveyUnit = surveyUnitService.updateSurveyUnit(surveyUnit);
         Response response = new Response(String.format("SurveyUnit %s data replaced", updatedSurveyUnit

--- a/controller/src/main/java/fr/insee/rem/controller/sources/CensusSource.java
+++ b/controller/src/main/java/fr/insee/rem/controller/sources/CensusSource.java
@@ -9,16 +9,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CensusSource {
-    private String idinternaute;
+    private Long id;
     private String numvoiloc;
     private String bisterloc;
     private String typevoiloc;
     private String nomvoiloc;
     private String resloc;
-    private String cloc;
+    private String car;
     private String cpostloc;
-    private String idenq;
+    private Long idInternaute;
     private String mail;
-    private String identifiant;
+    private String identifiantCompte;
     private JsonNode externals;
 }

--- a/controller/src/main/java/fr/insee/rem/controller/sources/CensusSource.java
+++ b/controller/src/main/java/fr/insee/rem/controller/sources/CensusSource.java
@@ -1,5 +1,6 @@
 package fr.insee.rem.controller.sources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CensusSource {
-    private String nothing;
+    private String idinternaute;
+    private String numvoiloc;
+    private String bisterloc;
+    private String typevoiloc;
+    private String nomvoiloc;
+    private String resloc;
+    private String cloc;
+    private String cpostloc;
+    private String idenq;
+    private String mail;
+    private String identifiant;
+    private JsonNode externals;
 }

--- a/controller/src/main/java/fr/insee/rem/controller/sources/CensusSource.java
+++ b/controller/src/main/java/fr/insee/rem/controller/sources/CensusSource.java
@@ -1,0 +1,12 @@
+package fr.insee.rem.controller.sources;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CensusSource {
+    private String nothing;
+}

--- a/controller/src/main/java/fr/insee/rem/controller/targets/SuIdMappingJsonTarget.java
+++ b/controller/src/main/java/fr/insee/rem/controller/targets/SuIdMappingJsonTarget.java
@@ -1,0 +1,19 @@
+package fr.insee.rem.controller.targets;
+
+import fr.insee.rem.domain.records.SuIdMappingRecord;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SuIdMappingJsonTarget {
+    private long partitionId;
+    private List<SuIdMappingRecord> data;
+    private int count;
+}

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -35,6 +35,11 @@
 		    <artifactId>junit-jupiter</artifactId>
 		    <scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.15.2</version>
+		</dependency>
 	</dependencies>	
 	<build>
 		<plugins>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -10,7 +10,7 @@
 	<artifactId>domain</artifactId>
 	<description>Survey unit repository - Business Logic</description>
 	<properties>
-		<pitest.version>1.14.1</pitest.version>
+		<pitest.version>1.14.2</pitest.version>
 		<pitest.junit.version>1.2.0</pitest.junit.version>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<sonar.language>java</sonar.language>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -10,7 +10,7 @@
 	<artifactId>domain</artifactId>
 	<description>Survey unit repository - Business Logic</description>
 	<properties>
-		<pitest.version>1.14.2</pitest.version>
+		<pitest.version>1.14.4</pitest.version>
 		<pitest.junit.version>1.2.0</pitest.junit.version>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<sonar.language>java</sonar.language>

--- a/domain/src/main/java/fr/insee/rem/domain/dtos/SurveyUnitDto.java
+++ b/domain/src/main/java/fr/insee/rem/domain/dtos/SurveyUnitDto.java
@@ -1,5 +1,8 @@
 package fr.insee.rem.domain.dtos;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.JsonNode;
+import fr.insee.rem.domain.views.Views;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -13,22 +16,24 @@ import java.util.Optional;
 @Data
 public class SurveyUnitDto {
 
+    @JsonView(value = {Views.SurveyUnitWithId.class, Views.SurveyUnitWithIdAndExternals.class})
     private Long repositoryId;
-
+    @JsonView(Views.SurveyUnitBase.class)
     private String externalId;
-
+    @JsonView(Views.SurveyUnitBase.class)
     private String externalName;
-
+    @JsonView(Views.SurveyUnitBase.class)
     private Context context;
-
+    @JsonView(Views.SurveyUnitBase.class)
     private AddressDto address;
-
     @Getter(AccessLevel.NONE)
     private List<PersonDto> persons;
-
+    @JsonView(Views.SurveyUnitBase.class)
     private OtherIdentifierDto otherIdentifier;
-
+    @JsonView(Views.SurveyUnitBase.class)
     private List<AdditionalInformationDto> additionalInformations;
+    @JsonView(value = {Views.SurveyUnitWithExternals.class, Views.SurveyUnitWithIdAndExternals.class})
+    private JsonNode externals;
 
     /**
      * Defining everyone's role (surveyed, main, coDeclarant)
@@ -36,6 +41,7 @@ public class SurveyUnitDto {
      *
      * @return the persons
      */
+    @JsonView(Views.SurveyUnitBase.class)
     public List<PersonDto> getPersons() {
         if (persons == null) {
             return List.of();

--- a/domain/src/main/java/fr/insee/rem/domain/ports/api/PartitionServicePort.java
+++ b/domain/src/main/java/fr/insee/rem/domain/ports/api/PartitionServicePort.java
@@ -14,4 +14,5 @@ public interface PartitionServicePort {
 
     List<PartitionDto> getAllPartitions();
 
+    void emptyPartitionById(Long partitionId);
 }

--- a/domain/src/main/java/fr/insee/rem/domain/ports/api/SurveyUnitServicePort.java
+++ b/domain/src/main/java/fr/insee/rem/domain/ports/api/SurveyUnitServicePort.java
@@ -30,4 +30,5 @@ public interface SurveyUnitServicePort {
 
     SurveyUnitDto updateSurveyUnit(SurveyUnitDto surveyUnit);
 
+    long countSurveyUnitsByPartition(Long partitionId);
 }

--- a/domain/src/main/java/fr/insee/rem/domain/ports/spi/PartitionSurveyUnitLinkPersistencePort.java
+++ b/domain/src/main/java/fr/insee/rem/domain/ports/spi/PartitionSurveyUnitLinkPersistencePort.java
@@ -20,4 +20,5 @@ public interface PartitionSurveyUnitLinkPersistencePort {
 
     List<SuIdMappingRecord> findSurveyUnitIdsMappingTableByPartitionId(Long partitionId);
 
+    long countByPartitionId(Long partitionId);
 }

--- a/domain/src/main/java/fr/insee/rem/domain/ports/spi/PartitionSurveyUnitLinkPersistencePort.java
+++ b/domain/src/main/java/fr/insee/rem/domain/ports/spi/PartitionSurveyUnitLinkPersistencePort.java
@@ -21,4 +21,6 @@ public interface PartitionSurveyUnitLinkPersistencePort {
     List<SuIdMappingRecord> findSurveyUnitIdsMappingTableByPartitionId(Long partitionId);
 
     long countByPartitionId(Long partitionId);
+
+    void removeSurveyUnitsFromPartition(Long partitionId);
 }

--- a/domain/src/main/java/fr/insee/rem/domain/service/PartitionServiceImpl.java
+++ b/domain/src/main/java/fr/insee/rem/domain/service/PartitionServiceImpl.java
@@ -5,6 +5,7 @@ import fr.insee.rem.domain.exception.PartitionAlreadyExistsException;
 import fr.insee.rem.domain.exception.PartitionNotFoundException;
 import fr.insee.rem.domain.ports.api.PartitionServicePort;
 import fr.insee.rem.domain.ports.spi.PartitionPersistencePort;
+import fr.insee.rem.domain.ports.spi.PartitionSurveyUnitLinkPersistencePort;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -14,9 +15,12 @@ import java.util.Optional;
 public class PartitionServiceImpl implements PartitionServicePort {
 
     private PartitionPersistencePort partitionPersistencePort;
+    private PartitionSurveyUnitLinkPersistencePort partitionSurveyUnitLinkPersistencePort;
 
-    public PartitionServiceImpl(PartitionPersistencePort partitionPersistencePort) {
+    public PartitionServiceImpl(PartitionPersistencePort partitionPersistencePort,
+                                PartitionSurveyUnitLinkPersistencePort partitionSurveyUnitLinkPersistencePort) {
         this.partitionPersistencePort = partitionPersistencePort;
+        this.partitionSurveyUnitLinkPersistencePort = partitionSurveyUnitLinkPersistencePort;
     }
 
     @Override
@@ -51,6 +55,15 @@ public class PartitionServiceImpl implements PartitionServicePort {
     public List<PartitionDto> getAllPartitions() {
         log.debug("domain: getAllPartitions()");
         return partitionPersistencePort.findAll();
+    }
+
+    @Override
+    public void emptyPartitionById(Long partitionId) {
+        log.debug("domain: emptyPartitionById({})", partitionId);
+        if (!partitionPersistencePort.existsById(partitionId)) {
+            throw new PartitionNotFoundException(partitionId);
+        }
+        partitionSurveyUnitLinkPersistencePort.removeSurveyUnitsFromPartition(partitionId);
     }
 
 }

--- a/domain/src/main/java/fr/insee/rem/domain/service/SurveyUnitServiceImpl.java
+++ b/domain/src/main/java/fr/insee/rem/domain/service/SurveyUnitServiceImpl.java
@@ -165,4 +165,13 @@ public class SurveyUnitServiceImpl implements SurveyUnitServicePort {
         return surveyUnitPersistencePort.update(surveyUnit);
     }
 
+    @Override
+    public long countSurveyUnitsByPartition(Long partitionId) {
+        log.debug("domain: countSurveyUnitsByPartition({})", partitionId);
+        if (!partitionPersistencePort.existsById(partitionId)) {
+            throw new PartitionNotFoundException(partitionId);
+        }
+        return partitionSurveyUnitLinkPersistencePort.countByPartitionId(partitionId);
+    }
+
 }

--- a/domain/src/main/java/fr/insee/rem/domain/views/Views.java
+++ b/domain/src/main/java/fr/insee/rem/domain/views/Views.java
@@ -1,0 +1,17 @@
+package fr.insee.rem.domain.views;
+
+public class Views {
+
+    public interface SurveyUnitBase {
+    }
+
+    public interface SurveyUnitWithId extends SurveyUnitBase {
+    }
+
+    public interface SurveyUnitWithExternals extends SurveyUnitBase {
+    }
+
+    public interface SurveyUnitWithIdAndExternals extends SurveyUnitWithId {
+    }
+
+}

--- a/domain/src/test/java/fr/insee/rem/domain/service/PartitionServiceTest.java
+++ b/domain/src/test/java/fr/insee/rem/domain/service/PartitionServiceTest.java
@@ -1,10 +1,15 @@
 package fr.insee.rem.domain.service;
 
+import fr.insee.rem.domain.dtos.Context;
 import fr.insee.rem.domain.dtos.PartitionDto;
+import fr.insee.rem.domain.dtos.PartitionSurveyUnitLinkDto;
+import fr.insee.rem.domain.dtos.SurveyUnitDto;
 import fr.insee.rem.domain.exception.PartitionAlreadyExistsException;
 import fr.insee.rem.domain.exception.PartitionNotFoundException;
 import fr.insee.rem.domain.ports.api.PartitionServicePort;
 import fr.insee.rem.domain.service.mock.PartitionPersistenceInMemory;
+import fr.insee.rem.domain.service.mock.PartitionSurveyUnitLinkPersistenceInMemory;
+import fr.insee.rem.domain.service.mock.SurveyUnitPersistenceInMemory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +19,11 @@ import java.util.List;
 class PartitionServiceTest {
 
     PartitionPersistenceInMemory partitionPersistenceInMemory = new PartitionPersistenceInMemory();
-    PartitionServicePort partitionService = new PartitionServiceImpl(partitionPersistenceInMemory);
+    SurveyUnitPersistenceInMemory surveyUnitPersistenceInMemory = new SurveyUnitPersistenceInMemory();
+    PartitionSurveyUnitLinkPersistenceInMemory partitionSurveyUnitLinkPersistenceInMemory =
+            new PartitionSurveyUnitLinkPersistenceInMemory(partitionPersistenceInMemory, surveyUnitPersistenceInMemory);
+    PartitionServicePort partitionService = new PartitionServiceImpl(partitionPersistenceInMemory,
+            partitionSurveyUnitLinkPersistenceInMemory);
 
     @Test
     void shouldCreatePartitionFromLabel() {
@@ -109,4 +118,38 @@ class PartitionServiceTest {
         Assertions.assertEquals(partitionOne, allPartitions.get(0));
         Assertions.assertEquals(partitionTwo, allPartitions.get(1));
     }
+
+    @Test
+    void shouldReturnPartitionNotFoundExceptionWhenDeleteSurveyUnitsFromNotExistingPartition() {
+        // Given
+        Long notExistingPartitionId = 99L;
+
+        // When + Then
+        PartitionNotFoundException exception = Assertions.assertThrows(PartitionNotFoundException.class,
+                () -> partitionService.emptyPartitionById(notExistingPartitionId));
+        Assertions.assertEquals(String.format("Partition [%s] doesn't exist", notExistingPartitionId),
+                exception.getMessage());
+    }
+
+    @Test
+    void shouldDeleteSurveyUnitsFromPartition() {
+        // Given
+        PartitionDto existingPartition = partitionService.createPartition("existing partition");
+        List<SurveyUnitDto> surveyUnitsToImport =
+                List.of(SurveyUnitDto.builder().context(Context.HOUSEHOLD).externalId("00001").build(),
+                        SurveyUnitDto.builder().context(Context.HOUSEHOLD).externalId("00002").build());
+        List<PartitionSurveyUnitLinkDto> importedPartitionSurveyUnits =
+                partitionSurveyUnitLinkPersistenceInMemory.saveAll(existingPartition.getPartitionId(),
+                        surveyUnitsToImport);
+
+        // When
+        partitionService.emptyPartitionById(existingPartition.getPartitionId());
+
+        // Then
+        List<PartitionSurveyUnitLinkDto> links =
+                partitionSurveyUnitLinkPersistenceInMemory.findSurveyUnitsByPartitionId(existingPartition.getPartitionId());
+        Assertions.assertEquals(0, links.size());
+    }
+
+
 }

--- a/domain/src/test/java/fr/insee/rem/domain/service/SurveyUnitServiceTest.java
+++ b/domain/src/test/java/fr/insee/rem/domain/service/SurveyUnitServiceTest.java
@@ -27,7 +27,8 @@ class SurveyUnitServiceTest {
 
     SurveyUnitServicePort surveyUnitService = new SurveyUnitServiceImpl(surveyUnitPersistenceInMemory,
             partitionSurveyUnitLinkPersistenceInMemory, partitionPersistenceInMemory);
-    PartitionServicePort partitionService = new PartitionServiceImpl(partitionPersistenceInMemory);
+    PartitionServicePort partitionService = new PartitionServiceImpl(partitionPersistenceInMemory,
+            partitionSurveyUnitLinkPersistenceInMemory);
 
     private List<PartitionSurveyUnitLinkDto> initDataPersistenceInMemoryWithOnePartitionAndTwoSurveyUnits(String label) {
         PartitionDto existingPartition = partitionService.createPartition(label);

--- a/domain/src/test/java/fr/insee/rem/domain/service/SurveyUnitServiceTest.java
+++ b/domain/src/test/java/fr/insee/rem/domain/service/SurveyUnitServiceTest.java
@@ -553,4 +553,44 @@ class SurveyUnitServiceTest {
         Assertions.assertEquals(surveyUnitToUpdate.getContext(), updatedSurveyUnit.getContext());
     }
 
+    @Test
+    void shouldReturn0WhenPartitionHaveNoSurveyUnit() {
+        // Given
+        PartitionDto partition = partitionService.createPartition("partition");
+        Long partitionId = partition.getPartitionId();
+
+        // When
+        long count = surveyUnitService.countSurveyUnitsByPartition(partitionId);
+
+        // Then
+        Assertions.assertEquals(0, count);
+    }
+
+    @Test
+    void shouldReturnNumberOfSurveyUnitWhenPartitionHaveSurveyUnit() {
+        // Given
+        List<PartitionSurveyUnitLinkDto> importedPartitionSurveyUnits =
+                initDataPersistenceInMemoryWithOnePartitionAndTwoSurveyUnits("init partition");
+        Long partitionId = importedPartitionSurveyUnits.get(0).getPartition().getPartitionId();
+
+        // When
+        long count = surveyUnitService.countSurveyUnitsByPartition(partitionId);
+
+        // Then
+        Assertions.assertEquals(2, count);
+    }
+
+    @Test
+    void shouldReturnPartitionNotFoundExceptionWhenCountSurveyUnitByNotExistingPartition() {
+        // Given
+        Long notExistingPartitionId = 99L;
+
+        // When + Then
+        PartitionNotFoundException exception =
+                Assertions.assertThrows(PartitionNotFoundException.class,
+                        () -> surveyUnitService.countSurveyUnitsByPartition(notExistingPartitionId));
+        Assertions.assertEquals(String.format("Partition [%s] doesn't exist", notExistingPartitionId),
+                exception.getMessage());
+    }
+
 }

--- a/domain/src/test/java/fr/insee/rem/domain/service/mock/PartitionSurveyUnitLinkPersistenceInMemory.java
+++ b/domain/src/test/java/fr/insee/rem/domain/service/mock/PartitionSurveyUnitLinkPersistenceInMemory.java
@@ -80,4 +80,9 @@ public class PartitionSurveyUnitLinkPersistenceInMemory implements PartitionSurv
                 .filter(link -> link.getPartition().getPartitionId().equals(partitionId))
                 .count();
     }
+
+    @Override
+    public void removeSurveyUnitsFromPartition(Long partitionId) {
+        partitionSurveyUnitLinks.removeIf(link -> link.getPartition().getPartitionId().equals(partitionId));
+    }
 }

--- a/domain/src/test/java/fr/insee/rem/domain/service/mock/PartitionSurveyUnitLinkPersistenceInMemory.java
+++ b/domain/src/test/java/fr/insee/rem/domain/service/mock/PartitionSurveyUnitLinkPersistenceInMemory.java
@@ -73,4 +73,11 @@ public class PartitionSurveyUnitLinkPersistenceInMemory implements PartitionSurv
                         link.getSurveyUnit().getExternalId()))
                 .toList();
     }
+
+    @Override
+    public long countByPartitionId(Long partitionId) {
+        return partitionSurveyUnitLinks.stream()
+                .filter(link -> link.getPartition().getPartitionId().equals(partitionId))
+                .count();
+    }
 }

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/adapter/PartitionSurveyUnitLinkJpaAdapter.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/adapter/PartitionSurveyUnitLinkJpaAdapter.java
@@ -91,4 +91,10 @@ public class PartitionSurveyUnitLinkJpaAdapter implements PartitionSurveyUnitLin
         return partitionSurveyUnitLinkRepository.findSuIdMappingByPartitionId(partitionId);
     }
 
+    @Override
+    public long countByPartitionId(Long partitionId) {
+        PartitionEntity partitionEntity = entityManager.find(PartitionEntity.class, partitionId);
+        return partitionSurveyUnitLinkRepository.countByPartition(partitionEntity);
+    }
+
 }

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/adapter/PartitionSurveyUnitLinkJpaAdapter.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/adapter/PartitionSurveyUnitLinkJpaAdapter.java
@@ -97,4 +97,13 @@ public class PartitionSurveyUnitLinkJpaAdapter implements PartitionSurveyUnitLin
         return partitionSurveyUnitLinkRepository.countByPartition(partitionEntity);
     }
 
+    @Override
+    public void removeSurveyUnitsFromPartition(Long partitionId) {
+        List<PartitionSurveyUnitLinkEntity> links =
+                partitionSurveyUnitLinkRepository.findAllSurveyUnitsByPartitionId(partitionId);
+        for (PartitionSurveyUnitLinkEntity link : links) {
+            partitionSurveyUnitLinkRepository.delete(link);
+        }
+    }
+
 }

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/AdditionalInformation.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/AdditionalInformation.java
@@ -4,17 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Data;
 
-import java.io.Serializable;
-
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class AdditionalInformation implements Serializable {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1278478308717480850L;
-
+public class AdditionalInformation {
     private String key;
     private String value;
 }

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/Address.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/Address.java
@@ -4,15 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Data;
 
-import java.io.Serializable;
-
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class Address implements Serializable {
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5012898811152555612L;
+public class Address {
     private String streetNumber;
     private String repetitionIndex;
     private String streetType;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/Email.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/Email.java
@@ -5,13 +5,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import fr.insee.rem.domain.dtos.Source;
 import lombok.Data;
 
-import java.io.Serializable;
-
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class Email implements Serializable {
-
-    private static final long serialVersionUID = -7908018292639977756L;
+public class Email {
     private Source source;
     private Boolean favorite;
     private String mailAddress;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/LocationHelp.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/LocationHelp.java
@@ -1,19 +1,12 @@
 package fr.insee.rem.infrastructure.entity;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import lombok.Data;
 
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class LocationHelp implements Serializable {
-    /**
-     * 
-     */
-    private static final long serialVersionUID = -2055977266574207443L;
+public class LocationHelp {
     private String cityCode;
     private String building;
     private String floor;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/OtherIdentifier.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/OtherIdentifier.java
@@ -4,16 +4,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Data;
 
-import java.io.Serializable;
-
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class OtherIdentifier implements Serializable {
+public class OtherIdentifier {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3113498426456374157L;
     private String numfa;
     private String rges;
     private String ssech;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PartitionEntity.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PartitionEntity.java
@@ -7,7 +7,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -15,12 +14,8 @@ import java.util.Set;
 @Table(name = "partition")
 @Data
 @NoArgsConstructor
-public class PartitionEntity implements Serializable {
+public class PartitionEntity {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1680693250888586880L;
 
     @Id
     @GeneratedValue(generator = "seq_partition", strategy = GenerationType.SEQUENCE)

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PartitionSurveyUnitLinkEntity.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PartitionSurveyUnitLinkEntity.java
@@ -3,19 +3,14 @@ package fr.insee.rem.infrastructure.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
-import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
 
 @Entity
 @Table(name = "partition_survey_unit_link")
 @Data
-public class PartitionSurveyUnitLinkEntity implements Serializable {
+public class PartitionSurveyUnitLinkEntity {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7546818970816616680L;
 
     @EmbeddedId
     private PartitionSurveyUnitLinkPK id;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PartitionSurveyUnitLinkPK.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PartitionSurveyUnitLinkPK.java
@@ -3,16 +3,11 @@ package fr.insee.rem.infrastructure.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
-import java.io.Serializable;
 import java.util.Objects;
 
 @Embeddable
-public class PartitionSurveyUnitLinkPK implements Serializable {
+public class PartitionSurveyUnitLinkPK {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1449181380370389057L;
 
     @Column(name = "partition_id")
     private Long partitionId;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/Person.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/Person.java
@@ -1,22 +1,15 @@
 package fr.insee.rem.infrastructure.entity;
 
-import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Data;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
-import lombok.Data;
-
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class Person implements Serializable {
-
-    /**
-     * 
-     */
-    private static final long serialVersionUID = 7165854120895777787L;
+public class Person {
 
     private Integer index;
     private String externalId;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PhoneNumber.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/PhoneNumber.java
@@ -5,13 +5,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import fr.insee.rem.domain.dtos.Source;
 import lombok.Data;
 
-import java.io.Serializable;
-
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class PhoneNumber implements Serializable {
-
-    private static final long serialVersionUID = -7908018292639977756L;
+public class PhoneNumber {
     private Source source;
     private Boolean favorite;
     private String number;

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/SurveyUnitData.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/SurveyUnitData.java
@@ -4,17 +4,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Data;
 
-import java.io.Serializable;
 import java.util.List;
 
 @Data
 @JsonInclude(Include.NON_EMPTY)
-public class SurveyUnitData implements Serializable {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 811623138921050269L;
+public class SurveyUnitData {
 
     private Address address;
 

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/SurveyUnitEntity.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/SurveyUnitEntity.java
@@ -10,19 +10,13 @@ import lombok.ToString;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
 @Data
 @Table(name = "survey_unit")
-public class SurveyUnitEntity implements Serializable {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5458959377889736946L;
+public class SurveyUnitEntity {
 
     @Id
     @GeneratedValue(generator = "seq_survey_unit", strategy = GenerationType.SEQUENCE)

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/SurveyUnitEntity.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/entity/SurveyUnitEntity.java
@@ -1,6 +1,7 @@
 package fr.insee.rem.infrastructure.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
 import fr.insee.rem.domain.dtos.Context;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -38,6 +39,10 @@ public class SurveyUnitEntity implements Serializable {
     @Column(columnDefinition = "jsonb", name = "data")
     @Basic(fetch = FetchType.EAGER)
     private SurveyUnitData surveyUnitData;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json", name = "externals")
+    private JsonNode externals;
 
     @OneToMany(mappedBy = "surveyUnit", orphanRemoval = false, cascade = CascadeType.REMOVE)
     @JsonIgnore

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/mappers/SurveyUnitMapper.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/mappers/SurveyUnitMapper.java
@@ -23,12 +23,14 @@ public interface SurveyUnitMapper {
     @Mapping(source = "persons", target = "surveyUnitData.persons")
     @Mapping(source = "otherIdentifier", target = "surveyUnitData.otherIdentifier")
     @Mapping(source = "additionalInformations", target = "surveyUnitData.additionalInformations")
+    @Mapping(source = "externals", target = "externals")
     SurveyUnitEntity dtoToEntity(SurveyUnitDto surveyUnit);
 
     @Mapping(target = "address", source = "surveyUnitData.address")
     @Mapping(target = "persons", source = "surveyUnitData.persons")
     @Mapping(target = "otherIdentifier", source = "surveyUnitData.otherIdentifier")
     @Mapping(target = "additionalInformations", source = "surveyUnitData.additionalInformations")
+    @Mapping(source = "externals", target = "externals")
     SurveyUnitDto entityToDto(SurveyUnitEntity surveyUnitEntity);
 
     List<SurveyUnitDto> listEntityToListDto(List<SurveyUnitEntity> surveyUnitEntities);

--- a/infrastructure/src/main/java/fr/insee/rem/infrastructure/repository/PartitionSurveyUnitLinkRepository.java
+++ b/infrastructure/src/main/java/fr/insee/rem/infrastructure/repository/PartitionSurveyUnitLinkRepository.java
@@ -1,6 +1,7 @@
 package fr.insee.rem.infrastructure.repository;
 
 import fr.insee.rem.domain.records.SuIdMappingRecord;
+import fr.insee.rem.infrastructure.entity.PartitionEntity;
 import fr.insee.rem.infrastructure.entity.PartitionSurveyUnitLinkEntity;
 import fr.insee.rem.infrastructure.entity.PartitionSurveyUnitLinkPK;
 import fr.insee.rem.infrastructure.entity.SurveyUnitEntity;
@@ -33,4 +34,5 @@ public interface PartitionSurveyUnitLinkRepository extends JpaRepository<Partiti
                     "su.repositoryId and link.partition.partitionId = ?1")
     List<SuIdMappingRecord> findSuIdMappingByPartitionId(Long partitionId);
 
+    long countByPartition(PartitionEntity partition);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </modules>
 
     <properties>
-        <revision>1.3.0-RC</revision>
+        <revision>1.3.0</revision>
         <java.version>17</java.version>
         <lombok.version>1.18.28</lombok.version>
         <slf4j.version>2.0.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>fr.insee.rem</groupId>
@@ -14,14 +14,14 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>application</module>
         <module>domain</module>
         <module>infrastructure</module>
         <module>controller</module>
+        <module>application</module>
     </modules>
 
     <properties>
-        <revision>1.2.0</revision>
+        <revision>1.3.0-SNAPSHOT</revision>
         <java.version>17</java.version>
         <lombok.version>1.18.28</lombok.version>
         <slf4j.version>2.0.7</slf4j.version>
@@ -44,22 +44,22 @@
             <dependency>
                 <groupId>fr.insee.rem</groupId>
                 <artifactId>application</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>fr.insee.rem</groupId>
                 <artifactId>domain</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>fr.insee.rem</groupId>
                 <artifactId>infrastructure</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>fr.insee.rem</groupId>
                 <artifactId>controller</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </modules>
 
     <properties>
-        <revision>1.3.0-SNAPSHOT</revision>
+        <revision>1.3.0-RC</revision>
         <java.version>17</java.version>
         <lombok.version>1.18.28</lombok.version>
         <slf4j.version>2.0.7</slf4j.version>


### PR DESCRIPTION
### Features
- Add list of ids into import returns
- Add "externals" field into survey unit: save in database without modification
- Add number of SurveyUnit into partition endpoint
- Import census survey units
- Empty a partition

### Refactoring
- use JsonView to manage the fields to return
- add content description in the OpenAPI documentation
- delete Serializable from Entity classes

### Dependencies updates
- spring-boot: 3.1.0 -> 3.1.1
- pitest-maven: 1.14.1 -> 1.14.4